### PR TITLE
Add black background with breathing halos

### DIFF
--- a/home.html
+++ b/home.html
@@ -11,8 +11,8 @@
     body {
       margin: 0;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      color: #0e0e0e;
-      background: #f7f7f7;
+      color: #fff;
+      background: #000;
       overflow-x: hidden;
     }
 
@@ -43,14 +43,17 @@
       background: linear-gradient(135deg, #00d2ff, #3a7bd5);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
-      text-shadow: 0 0 15px rgba(0,210,255,0.6);
-      animation: breathe 3s ease-in-out infinite;
+      text-shadow: 0 0 10px rgba(0,210,255,0.4), 0 0 20px rgba(0,210,255,0.2);
+      animation: halo 3s ease-in-out infinite;
     }
 
-    @keyframes breathe {
-      0% { transform: scale(1); }
-      50% { transform: scale(1.05); }
-      100% { transform: scale(1); }
+    @keyframes halo {
+      0%, 100% {
+        text-shadow: 0 0 10px rgba(0,210,255,0.4), 0 0 20px rgba(0,210,255,0.2);
+      }
+      50% {
+        text-shadow: 0 0 25px rgba(0,210,255,0.9), 0 0 35px rgba(0,210,255,0.7);
+      }
     }
 
     header p {
@@ -117,7 +120,8 @@
           vx: (Math.random() - 0.5) * 0.3,
           vy: (Math.random() - 0.5) * 0.3,
           r: 8 + Math.random() * 4,
-          color: colors[Math.floor(Math.random() * colors.length)]
+          color: colors[Math.floor(Math.random() * colors.length)],
+          phase: Math.random() * Math.PI * 2
         });
       }
     }
@@ -126,6 +130,7 @@
 
     function draw() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const time = performance.now() * 0.002;
       for (let i = 0; i < particles.length; i++) {
         const p = particles[i];
         p.x += p.vx;
@@ -136,10 +141,13 @@
         const grad = ctx.createRadialGradient(p.x - p.r / 3, p.y - p.r / 3, p.r / 5, p.x, p.y, p.r);
         grad.addColorStop(0, '#fff');
         grad.addColorStop(1, p.color);
+        ctx.shadowColor = p.color;
+        ctx.shadowBlur = 20 + 10 * Math.sin(time + p.phase);
         ctx.beginPath();
         ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
         ctx.fillStyle = grad;
         ctx.fill();
+        ctx.shadowBlur = 0;
 
         for (let j = i + 1; j < particles.length; j++) {
           const q = particles[j];
@@ -147,7 +155,7 @@
           const dy = p.y - q.y;
           const dist = Math.hypot(dx, dy);
           if (dist < 120) {
-            ctx.strokeStyle = p.color;
+            ctx.strokeStyle = '#fff';
             ctx.globalAlpha = 0.3;
             ctx.lineWidth = 1;
             ctx.beginPath();

--- a/visuals.html
+++ b/visuals.html
@@ -11,8 +11,8 @@
     body {
       margin: 0;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      color: #0e0e0e;
-      background: #f7f7f7;
+      color: #fff;
+      background: #000;
       overflow-x: hidden;
     }
 
@@ -111,7 +111,8 @@
           vx: (Math.random() - 0.5) * 0.3,
           vy: (Math.random() - 0.5) * 0.3,
           r: 8 + Math.random() * 4,
-          color: colors[Math.floor(Math.random() * colors.length)]
+          color: colors[Math.floor(Math.random() * colors.length)],
+          phase: Math.random() * Math.PI * 2
         });
       }
     }
@@ -120,6 +121,7 @@
 
     function draw() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const time = performance.now() * 0.002;
       for (let i = 0; i < particles.length; i++) {
         const p = particles[i];
         p.x += p.vx;
@@ -130,10 +132,13 @@
         const grad = ctx.createRadialGradient(p.x - p.r / 3, p.y - p.r / 3, p.r / 5, p.x, p.y, p.r);
         grad.addColorStop(0, '#fff');
         grad.addColorStop(1, p.color);
+        ctx.shadowColor = p.color;
+        ctx.shadowBlur = 20 + 10 * Math.sin(time + p.phase);
         ctx.beginPath();
         ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
         ctx.fillStyle = grad;
         ctx.fill();
+        ctx.shadowBlur = 0;
 
         for (let j = i + 1; j < particles.length; j++) {
           const q = particles[j];
@@ -141,7 +146,7 @@
           const dy = p.y - q.y;
           const dist = Math.hypot(dx, dy);
           if (dist < 120) {
-            ctx.strokeStyle = p.color;
+            ctx.strokeStyle = '#fff';
             ctx.globalAlpha = 0.3;
             ctx.lineWidth = 1;
             ctx.beginPath();


### PR DESCRIPTION
## Summary
- Set site body background to black and text to white
- Replace scaling animation on "Vivome" title with a breathing halo glow
- Draw particle connections in white and give each particle a pulsing glow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cec846104832f8618a4c771e207c0