### PR TITLE
feat: combine protein background with smoky title overlay

### DIFF
--- a/home.html
+++ b/home.html
@@ -96,21 +96,42 @@
       }
 
 
-      /* Smoke canvas */
-      #smoke-canvas {
-        position: absolute;
+      /* Protein background */
+      #protein-canvas {
+        position: fixed;
         top: 0;
         left: 0;
         width: 100%;
         height: 100%;
         z-index: -1;
+        background: #000;
         pointer-events: none;
+      }
+
+      /* Smoke area */
+      #smoke-container {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 100%;
+        height: 50vh;
+        z-index: -1;
+        pointer-events: none;
+      }
+      #smoke-canvas {
+        width: 100%;
+        height: 100%;
       }
     </style>
   </head>
   <body>
+    <canvas id="protein-canvas"></canvas>
+
     <section id="home">
-      <canvas id="smoke-canvas"></canvas>
+      <div id="smoke-container">
+        <canvas id="smoke-canvas"></canvas>
+      </div>
       <h1>Vivome</h1>
       <p>A Living Joint Latent Atlas for Single-Cell Omics</p>
     </section>
@@ -180,79 +201,142 @@
     </section>
     <script src="https://unpkg.com/three@0.153.0/build/three.min.js"></script>
     <script>
+      // Protein background animation
+      const canvas = document.getElementById("protein-canvas");
+      const ctx = canvas.getContext("2d");
+      const colors = ["#ff6b6b", "#f0a500", "#4ecdc4", "#3a7bd5", "#b388eb"];
+      let particles = [];
+      let cw, ch, dpr;
+
+      function resize() {
+        dpr = window.devicePixelRatio || 1;
+        cw = window.innerWidth;
+        ch = window.innerHeight;
+        canvas.width = cw * dpr;
+        canvas.height = ch * dpr;
+        canvas.style.width = cw + "px";
+        canvas.style.height = ch + "px";
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        initParticles();
+      }
+      window.addEventListener("resize", resize);
+      resize();
+
+      function initParticles() {
+        particles = [];
+        const count = Math.floor((cw + ch) / 50);
+        for (let i = 0; i < count; i++) {
+          particles.push({
+            x: Math.random() * cw,
+            y: Math.random() * ch,
+            vx: (Math.random() - 0.5) * 0.3,
+            vy: (Math.random() - 0.5) * 0.3,
+            r: 8 + Math.random() * 4,
+            color: colors[Math.floor(Math.random() * colors.length)],
+            phase: Math.random() * Math.PI * 2,
+          });
+        }
+      }
+
+      function draw() {
+        ctx.clearRect(0, 0, cw, ch);
+        const time = performance.now() * 0.002;
+        for (let i = 0; i < particles.length; i++) {
+          const p = particles[i];
+          p.x += p.vx;
+          p.y += p.vy;
+          if (p.x < 0 || p.x > cw) p.vx *= -1;
+          if (p.y < 0 || p.y > ch) p.vy *= -1;
+
+          const grad = ctx.createRadialGradient(
+            p.x - p.r / 3,
+            p.y - p.r / 3,
+            p.r / 5,
+            p.x,
+            p.y,
+            p.r
+          );
+          grad.addColorStop(0, "#fff");
+          grad.addColorStop(1, p.color);
+          ctx.shadowColor = p.color;
+          ctx.shadowBlur = 20 + 10 * Math.sin(time + p.phase);
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+          ctx.fillStyle = grad;
+          ctx.fill();
+          ctx.shadowBlur = 0;
+
+          for (let j = i + 1; j < particles.length; j++) {
+            const q = particles[j];
+            const dx = p.x - q.x;
+            const dy = p.y - q.y;
+            const dist = Math.hypot(dx, dy);
+            if (dist < 120) {
+              ctx.strokeStyle = "#fff";
+              ctx.globalAlpha = 0.3;
+              ctx.lineWidth = 1;
+              ctx.beginPath();
+              ctx.moveTo(p.x, p.y);
+              ctx.lineTo(q.x, q.y);
+              ctx.stroke();
+              ctx.globalAlpha = 1;
+            }
+          }
+        }
+        requestAnimationFrame(draw);
+      }
+      draw();
+
+      // Smoke effect over title
       const smokeCanvas = document.getElementById("smoke-canvas");
-      const renderer = new THREE.WebGLRenderer({
-        canvas: smokeCanvas,
-        alpha: true,
-      });
+      const smokeContainer = document.getElementById("smoke-container");
+      const renderer = new THREE.WebGLRenderer({ canvas: smokeCanvas, alpha: true });
       const scene = new THREE.Scene();
-      const camera = new THREE.PerspectiveCamera(
-        60,
-        window.innerWidth / window.innerHeight,
-        1,
-        1000
-      );
-      camera.position.z = 400;
+      const camera = new THREE.PerspectiveCamera(50, 1, 1, 1000);
+      camera.position.z = 100;
 
-      function onResize() {
-        const w = window.innerWidth;
-        const h = document.getElementById("home").offsetHeight;
-        renderer.setSize(w, h);
-        camera.aspect = w / h;
-        camera.updateProjectionMatrix();
-      }
-      window.addEventListener("resize", onResize);
-      onResize();
-
-      const particleCount = 5000;
-      const geometry = new THREE.BufferGeometry();
-      const positions = new Float32Array(particleCount * 3);
-      const colors = new Float32Array(particleCount * 3);
-      const color = new THREE.Color();
-      for (let i = 0; i < particleCount; i++) {
-        const x = (Math.random() - 0.5) * 400;
-        const y = (Math.random() - 0.5) * 200;
-        const z = (Math.random() - 0.5) * 400;
-        positions[i * 3] = x;
-        positions[i * 3 + 1] = y;
-        positions[i * 3 + 2] = z;
-        color.setHSL(Math.random(), 1, 0.5);
-        colors[i * 3] = color.r;
-        colors[i * 3 + 1] = color.g;
-        colors[i * 3 + 2] = color.b;
-      }
-      geometry.setAttribute(
-        "position",
-        new THREE.BufferAttribute(positions, 3)
-      );
-      geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
-
-      const material = new THREE.PointsMaterial({
-        size: 10,
-        transparent: true,
-        opacity: 0.4,
-        vertexColors: true,
-        blending: THREE.AdditiveBlending,
-        depthWrite: false,
+      const cloudParticles = [];
+      const loader = new THREE.TextureLoader();
+      loader.load("https://threejs.org/examples/textures/smoke.png", (texture) => {
+        const cloudGeo = new THREE.PlaneGeometry(300, 300);
+        const cloudMaterial = new THREE.MeshLambertMaterial({
+          map: texture,
+          transparent: true,
+          opacity: 0.4,
+        });
+        for (let p = 0; p < 20; p++) {
+          const cloud = new THREE.Mesh(cloudGeo, cloudMaterial);
+          cloud.position.set(
+            Math.random() * 200 - 100,
+            Math.random() * 100 - 50,
+            Math.random() * 100 - 50
+          );
+          cloud.rotation.z = Math.random() * Math.PI * 2;
+          scene.add(cloud);
+          cloudParticles.push(cloud);
+        }
+        const light = new THREE.DirectionalLight(0xffffff, 0.5);
+        light.position.set(0, 0, 1);
+        scene.add(light);
+        animate();
       });
-
-      const points = new THREE.Points(geometry, material);
-      scene.add(points);
 
       function animate() {
         requestAnimationFrame(animate);
-        const t = Date.now() * 0.00005;
-        for (let i = 0; i < particleCount; i++) {
-          const idx = i * 3;
-          positions[idx] += Math.cos(t + i) * 0.1;
-          positions[idx + 1] += Math.sin(t + i) * 0.1;
-        }
-        geometry.attributes.position.needsUpdate = true;
-        points.rotation.y += 0.0005;
-        points.rotation.x += 0.0003;
+        cloudParticles.forEach((p) => {
+          p.rotation.z += 0.002;
+        });
         renderer.render(scene, camera);
       }
-      animate();
+
+      function resizeSmoke() {
+        const rect = smokeContainer.getBoundingClientRect();
+        renderer.setSize(rect.width, rect.height);
+        camera.aspect = rect.width / rect.height;
+        camera.updateProjectionMatrix();
+      }
+      window.addEventListener("resize", resizeSmoke);
+      resizeSmoke();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restore floating protein background
- add white smoke overlay behind hero title using Three.js

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d07a1e4f4832fa2b84bf4f90442ec