### PR TITLE
feat: enhance landing spheres

### DIFF
--- a/home.html
+++ b/home.html
@@ -79,18 +79,37 @@
     scene.add(new THREE.AmbientLight(0xffffff, 0.3));
 
     const spheres = [];
+    const glowTexture = new THREE.TextureLoader().load(
+      'https://threejs.org/examples/textures/sprites/glow.png'
+    );
     const sphereInfo = [
-      { pos: new THREE.Vector3(-1.5, 0, 0), color: 0xff6b6b, url: 'documentation.html' },
-      { pos: new THREE.Vector3(0, 0, 0), color: 0xf0a500, url: 'visual.html' },
-      { pos: new THREE.Vector3(1.5, 0, 0), color: 0x4ecdc4, url: 'code.html' },
+      { pos: new THREE.Vector3(-0.5, 1, 0), color: 0xff6b6b, url: 'documentation.html' },
+      { pos: new THREE.Vector3(0.5, 0, 0), color: 0xf0a500, url: 'visual.html' },
+      { pos: new THREE.Vector3(-0.5, -1, 0), color: 0x4ecdc4, url: 'code.html' },
     ];
 
     const group = new THREE.Group();
     sphereInfo.forEach(info => {
-      const geom = new THREE.SphereGeometry(0.4, 32, 32);
-      const mat = new THREE.MeshStandardMaterial({ color: info.color });
+      const geom = new THREE.SphereGeometry(0.2, 32, 32);
+      const mat = new THREE.MeshStandardMaterial({
+        color: info.color,
+        emissive: info.color,
+        emissiveIntensity: 1,
+      });
       const mesh = new THREE.Mesh(geom, mat);
       mesh.position.copy(info.pos);
+      const glow = new THREE.Sprite(
+        new THREE.SpriteMaterial({
+          map: glowTexture,
+          color: info.color,
+          transparent: true,
+          blending: THREE.AdditiveBlending,
+          depthWrite: false,
+        })
+      );
+      glow.scale.set(0.8, 0.8, 1);
+      mesh.add(glow);
+      mesh.add(new THREE.PointLight(info.color, 1, 2));
       mesh.userData.url = info.url;
       spheres.push(mesh);
       group.add(mesh);
@@ -103,6 +122,7 @@
       group.add(new THREE.Line(geo, lineMaterial));
     }
 
+    group.scale.set(0.8, 0.8, 0.8);
     scene.add(group);
 
     const raycaster = new THREE.Raycaster();


### PR DESCRIPTION
## Summary
- add neon glow and halo sprites for Three.js spheres
- arrange spheres in a vertical zigzag and scale them down

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d1975d0b0832fb3bc4443f8090f1b